### PR TITLE
Add exercises for schemas + associations

### DIFF
--- a/bin/run_association_exercises
+++ b/bin/run_association_exercises
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mix test test/music_db/exercises/association_exercises_test.exs
+

--- a/lib/music_db/album.ex
+++ b/lib/music_db/album.ex
@@ -1,7 +1,7 @@
 defmodule MusicDB.Album do
   use Ecto.Schema
   import Ecto.Changeset
-  alias MusicDB.{Artist, Track, Genre}
+  alias MusicDB.{Artist, Track, Genre, Release}
 
   schema "albums" do
     field(:title, :string)

--- a/lib/music_db/exercises/association_exercises.ex
+++ b/lib/music_db/exercises/association_exercises.ex
@@ -1,0 +1,21 @@
+defmodule MusicDB.Exercises.AssociationExercises do
+  import Ecto.Query
+  alias MusicDB.{Repo, Album, Release}
+
+  def insert_album_and_release do
+    # insert an album with the title "Giant Steps" along with an associated release with the
+    # title "Giant Steps (remastered)"
+
+  end
+
+  def fetch_album_with_releases do
+    # load the album with the title "Giant Steps" and make sure the releases are preloaded
+
+  end
+
+  def delete_album_and_release(album) do
+    # delete the given album - make sure the association is setup so that the associated release
+    # is deleted as well
+
+  end
+end

--- a/lib/music_db/release.ex
+++ b/lib/music_db/release.ex
@@ -1,0 +1,16 @@
+defmodule MusicDB.Release do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias MusicDB.Album
+
+  # create the schema for releases table here - it should have the following fields:
+  #   title (string)
+  #   release_date (date)
+  #   timestamps
+  # and have a belongs_to association with albums - you'll also need to add a has_many
+  # association between albums and releases
+  schema "releases" do
+
+  end
+
+end

--- a/priv/repo/migrations/20180903041220_add_releases.exs
+++ b/priv/repo/migrations/20180903041220_add_releases.exs
@@ -1,0 +1,14 @@
+defmodule MusicDB.Repo.Migrations.AddReleases do
+  use Ecto.Migration
+
+  def change do
+    create table(:releases) do
+      add :title, :string, null: false
+      add :release_date, :date, null: true
+      add :album_id, references(:albums, on_delete: :delete_all)
+      timestamps()
+    end
+
+    create index(:releases, :album_id)
+  end
+end

--- a/test/music_db/exercises/association_exercises_test.exs
+++ b/test/music_db/exercises/association_exercises_test.exs
@@ -1,0 +1,40 @@
+defmodule AssociationExercisesTest do
+  use MusicDB.DBCase
+  import Ecto.Query
+  alias MusicDB.Exercises.AssociationExercises
+  alias MusicDB.{Repo, Album, Release}
+
+  @tag :skip
+  test "create a has_many association between albums and releases" do
+    {:ok, album} = Repo.insert(%Album{title: "Dark Side Of The Moon"})
+    assert %Release{} = Ecto.build_assoc(album, :releases)
+  end
+
+  @tag :skip
+  test "insert album and release" do
+    AssociationExercises.insert_album_and_release
+    album = Repo.get_by(Album, title: "Giant Steps")
+    release = Repo.get_by(Release, title: "Giant Steps (remastered)")
+    assert release.album_id == album.id
+  end
+
+  @tag :skip
+  test "fetching an album and its preloaded releases" do
+    AssociationExercises.insert_album_and_release
+    album = AssociationExercises.fetch_album_with_releases
+    assert album.title == "Giant Steps"
+    releases = album.releases
+    assert Enum.count(releases) == 1
+    assert Enum.map(releases, &(&1.title)) == ["Giant Steps (remastered)"]
+  end
+
+  @tag :skip
+  test "delete an album and its associated release" do
+    AssociationExercises.insert_album_and_release
+    album = Repo.get_by(Album, title: "Giant Steps")
+    AssociationExercises.delete_album_and_release(album)
+    assert Repo.get_by(Album, title: "Giant Steps") == nil
+    assert Repo.get_by(Release, title: "Giant Steps (remastered)") == nil
+  end
+end
+


### PR DESCRIPTION
This adds exercises for adding associations to schemas. 

This just covers the basics of declaring associations, and performing simple inserts, queries and deletes. We'll get into the real nitty-gritty with the `Changeset` exercises.