### PR TITLE
Remove obsolete Ecto.Date reference and fix seeds file

### DIFF
--- a/lib/music_db/exercises/schema_exercises.ex
+++ b/lib/music_db/exercises/schema_exercises.ex
@@ -11,7 +11,7 @@ defmodule MusicDB.Exercises.SchemaExercises do
     # Convert the query below to use the Artist schema.
     query =
       from(a in "artists",
-        where: a.birth_date >= ^Ecto.Date.cast!("1990-11-15"),
+        where: a.birth_date >= ^~D[1990-11-15],
         select: [a.name]
       )
 
@@ -20,9 +20,11 @@ defmodule MusicDB.Exercises.SchemaExercises do
 
   def insert_a_track! do
     # Use Repo.insert! to insert a %Track{} with whatever title and index you like.
+
   end
 
   def delete_an_album!(album) do
     # Use Repo.delete to delete the album
+
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,8 +1,10 @@
 alias MusicDB.Repo
 alias MusicDB.{Artist, Album, Track, Genre}
 
-jazz_genre = Repo.insert!(%Genre{ name: "jazz", wiki_tag: "Jazz" })
-live_genre = Repo.insert!(%Genre{ name: "live", wiki_tag: "Concert" })
+jazz_genre = Repo.insert!(%Genre{ name: "jazz", wiki_tag: "Jazz" }, on_conflict: :replace_all_except_primary_key,
+  conflict_target: :name)
+live_genre = Repo.insert!(%Genre{ name: "live", wiki_tag: "Concert" }, on_conflict: :replace_all_except_primary_key,
+  conflict_target: :name)
 
 Repo.insert! %Artist{
   name: "Miles Davis",

--- a/test/music_db/exercises/schema_exercises_test.exs
+++ b/test/music_db/exercises/schema_exercises_test.exs
@@ -13,7 +13,8 @@ defmodule SchemaExercisesTest do
   test "convert schema-less query" do
     artists =
       for n <- 1..5 do
-        Repo.insert!(%Artist{name: "n", birth_date: Ecto.Date.cast!("1990-11-1#{n}")})
+        {:ok, date} = Date.new(1990, 11, 10 + n)
+        Repo.insert!(%Artist{name: "n", birth_date: date})
       end
 
     [artist] = SchemaExercises.convert_schema_less_query()


### PR DESCRIPTION
One more tweak to make the code Ecto-3-friendly. This also changes the `seeds.rb` to not crash if it's run a second time before clearing the database.