### PR TITLE
Remove upsert in seeds - doesn't work in Postgres < 9.5

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,10 +1,8 @@
 alias MusicDB.Repo
 alias MusicDB.{Artist, Album, Track, Genre}
 
-jazz_genre = Repo.insert!(%Genre{ name: "jazz", wiki_tag: "Jazz" }, on_conflict: :replace_all_except_primary_key,
-  conflict_target: :name)
-live_genre = Repo.insert!(%Genre{ name: "live", wiki_tag: "Concert" }, on_conflict: :replace_all_except_primary_key,
-  conflict_target: :name)
+jazz_genre = Repo.insert!(%Genre{ name: "jazz", wiki_tag: "Jazz" })
+live_genre = Repo.insert!(%Genre{ name: "live", wiki_tag: "Concert" })
 
 Repo.insert! %Artist{
   name: "Miles Davis",


### PR DESCRIPTION
This removes the upsert logic in the seeds file when adding the genres. As noted by @kenny-evitt in #10, the `ON CONFLICT` cause is not supported in Postgres before version 9.5.

The idea was to try to prevent the script from crashing if the user runs `bin/setup` a second time, but that's probably not super important. A better long-term solution would be to make the whole script idempotent.