### PR TITLE
Make "create a changeset from a map" test break properly

### DIFF
--- a/test/music_db/exercises/changeset_exercises_test.exs
+++ b/test/music_db/exercises/changeset_exercises_test.exs
@@ -11,7 +11,7 @@ defmodule ChangesetExercisesTest do
 
   @tag :skip
   test "create a changeset from a map" do
-    params = %{name: "Bobby Hutcherson", birth_date: "1941-01-27", instrument: "vibraphone"}
+    params = %{name: "Bobby Hutcherson", birth_date: "1941-01-27", death_date: "2016-08-15"}
     changeset = ChangesetExercises.create_changeset_from_map(params)
     assert changeset.data == %Artist{}
     assert changeset.changes == %{name: "Bobby Hutcherson", birth_date: ~D[1941-01-27]}


### PR DESCRIPTION
Since `instrument` isn't in the `Artist` schema, it appears Ecto strips that key from the input for us. To make this test break when the user hasn't properly limited the changeset to the specified keys, we need to provide a column that exists in the schema (`death_date`).